### PR TITLE
<PointLight> and <SpotLight> shadow property fix

### DIFF
--- a/src/lib/lights/PointLight.svelte
+++ b/src/lib/lights/PointLight.svelte
@@ -55,7 +55,7 @@
   {position}
   {scale}
   {rotation}
-  castShadow={shadow ? true : undefined}
+  castShadow={shadow ? true : false}
   {receiveShadow}
   {frustumCulled}
   {renderOrder}

--- a/src/lib/lights/SpotLight.svelte
+++ b/src/lib/lights/SpotLight.svelte
@@ -111,7 +111,7 @@
   {position}
   {scale}
   {rotation}
-  castShadow={shadow ? true : undefined}
+  castShadow={shadow ? true : false}
   {receiveShadow}
   {frustumCulled}
   {renderOrder}


### PR DESCRIPTION
The property `castShadow` on the `Object3DInstance` would not change when set back to undefined.