### PR TITLE
I decided to give default values on Instance components a try. Also goes for internal (functional) components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,9 +685,7 @@ viewportleave: undefined
 
 #### :recycle: Object Instances
 
-While object components like `<Mesh>` create a new object for you (in the case of `<Mesh>` it's a `THREE.Mesh`), an object instance component takes an existing object instance (`THREE.Mesh`, `THREE.Object3D`, `THREE.Light` or `THREE.Camera`) as a property and applies reactivity to it. It's used internally but can also be used to introduce reactivity to objects that need to be instanced manually, imported models or objects that did not yet make it into threlte.
-
-Object instance components intentionally have no default values on properties even if they can be `undefined`. That way, your IDE will tell you what properties need to be implemented to properly set them up.
+While components like `<Mesh>` and `<Group>` create a new object for you (in the case of `<Mesh>` it's a `THREE.Mesh`), an object instance component accepts an existing object instance (`THREE.Mesh`, `THREE.Object3D`, `THREE.Light` or `THREE.Camera`) as a property and applies reactivity to it. It's used internally but can also be used to introduce reactivity to objects that need to be instanced manually as well as imported models or objects that did not yet make it into threlte.
 
 ###### Example <!-- omit in toc -->
 
@@ -727,17 +725,17 @@ Object instance components intentionally have no default values on properties ev
 ```ts
 // required
 object: THREE.Object3D
-viewportAware: boolean
 
 // optional
-position: Position | undefined
-scale: Scale | undefined
-rotation: Rotation | undefined
-lookAt: LookAt | undefined
-castShadow: boolean | undefined
-receiveShadow: boolean | undefined
-frustumCulled: boolean | undefined
-renderOrder: number | undefined
+viewportAware: boolean = false
+position: Position | undefined = undefined
+scale: Scale | undefined = undefined
+rotation: Rotation | undefined = undefined
+lookAt: LookAt | undefined = undefined
+castShadow: boolean | undefined = undefined
+receiveShadow: boolean | undefined = undefined
+frustumCulled: boolean | undefined = undefined
+renderOrder: number | undefined = undefined
 ```
 
 ###### Bindings <!-- omit in toc -->
@@ -778,19 +776,19 @@ viewportleave: undefined
 ```ts
 // required
 mesh: THREE.Mesh
-interactive: boolean
-ignorePointerEvents: boolean
-viewportAware: boolean
 
 // optional
-position: Position | undefined
-scale: Scale | undefined
-rotation: Rotation | undefined
-lookAt: LookAt | undefined
-castShadow: boolean | undefined
-receiveShadow: boolean | undefined
-frustumCulled: boolean | undefined
-renderOrder: number | undefined
+interactive: boolean = false
+ignorePointerEvents: boolean = false
+viewportAware: boolean = false
+position: Position | undefined = undefined
+scale: Scale | undefined = undefined
+rotation: Rotation | undefined = undefined
+lookAt: LookAt | undefined = undefined
+castShadow: boolean | undefined = undefined
+receiveShadow: boolean | undefined = undefined
+frustumCulled: boolean | undefined = undefined
+renderOrder: number | undefined = undefined
 ```
 
 ###### Bindings <!-- omit in toc -->
@@ -833,18 +831,18 @@ pointermove: CustomEvent<ThreltePointerEvent>
 ```ts
 // required
 camera: THREE.Camera
-viewportAware: boolean
-useCamera: boolean
 
 // optional
-position: Position | undefined
-scale: Scale | undefined
-rotation: Rotation | undefined
-lookAt: LookAt | undefined
-castShadow: boolean | undefined
-receiveShadow: boolean | undefined
-frustumCulled: boolean | undefined
-renderOrder: number | undefined
+viewportAware: boolean = false
+useCamera: boolean = false
+position: Position | undefined = undefined
+scale: Scale | undefined = undefined
+rotation: Rotation | undefined = undefined
+lookAt: LookAt | undefined = undefined
+castShadow: boolean | undefined = undefined
+receiveShadow: boolean | undefined = undefined
+frustumCulled: boolean | undefined = undefined
+renderOrder: number | undefined = undefined
 ```
 
 ###### Bindings <!-- omit in toc -->
@@ -885,19 +883,19 @@ viewportleave: undefined
 ```ts
 // required
 light: THREE.Light
-viewportAware: boolean
 
 // optional
-position: Position | undefined
-scale: Scale | undefined
-rotation: Rotation | undefined
-lookAt: LookAt | undefined
-castShadow: boolean | undefined
-receiveShadow: boolean | undefined
-frustumCulled: boolean | undefined
-renderOrder: number | undefined
-color: THREE.ColorRepresentation | undefined
-intensity: number | undefined
+viewportAware: boolean = false
+position: Position | undefined = undefined
+scale: Scale | undefined = undefined
+rotation: Rotation | undefined = undefined
+lookAt: LookAt | undefined = undefined
+castShadow: boolean | undefined = undefined
+receiveShadow: boolean | undefined = undefined
+frustumCulled: boolean | undefined = undefined
+renderOrder: number | undefined = undefined
+color: THREE.ColorRepresentation | undefined = undefined
+intensity: number | undefined = undefined
 ```
 
 ###### Bindings <!-- omit in toc -->

--- a/src/lib/controls/OrbitControls.svelte
+++ b/src/lib/controls/OrbitControls.svelte
@@ -121,10 +121,4 @@
   })
 </script>
 
-<TransformableObject
-  object={targetObject}
-  position={target}
-  rotation={undefined}
-  scale={undefined}
-  lookAt={undefined}
-/>
+<TransformableObject object={targetObject} position={target} />

--- a/src/lib/instances/CameraInstance.svelte
+++ b/src/lib/instances/CameraInstance.svelte
@@ -5,19 +5,18 @@
 
   export let camera: CameraInstanceProperties['camera']
 
-  export let position: CameraInstanceProperties['position']
-  export let scale: CameraInstanceProperties['scale']
-  export let rotation: CameraInstanceProperties['rotation']
-  export let viewportAware: CameraInstanceProperties['viewportAware']
-  export let inViewport: CameraInstanceProperties['inViewport']
-  export let castShadow: CameraInstanceProperties['castShadow']
-  export let receiveShadow: CameraInstanceProperties['receiveShadow']
-  export let frustumCulled: CameraInstanceProperties['frustumCulled']
-  export let renderOrder: CameraInstanceProperties['renderOrder']
-  export let lookAt: CameraInstanceProperties['lookAt']
+  export let position: CameraInstanceProperties['position'] = undefined
+  export let scale: CameraInstanceProperties['scale'] = undefined
+  export let rotation: CameraInstanceProperties['rotation'] = undefined
+  export let lookAt: CameraInstanceProperties['lookAt'] = undefined
+  export let viewportAware: CameraInstanceProperties['viewportAware'] = false
+  export let inViewport: CameraInstanceProperties['inViewport'] = false
+  export let castShadow: CameraInstanceProperties['castShadow'] = undefined
+  export let receiveShadow: CameraInstanceProperties['receiveShadow'] = undefined
+  export let frustumCulled: CameraInstanceProperties['frustumCulled'] = undefined
+  export let renderOrder: CameraInstanceProperties['renderOrder'] = undefined
 
-  // self
-  export let useCamera: CameraInstanceProperties['useCamera']
+  export let useCamera: CameraInstanceProperties['useCamera'] = false
 
   const { setCamera } = useThrelteRoot()
 

--- a/src/lib/instances/LightInstance.svelte
+++ b/src/lib/instances/LightInstance.svelte
@@ -5,20 +5,21 @@
   import type { LightInstanceProperties } from '../types/components'
   import Object3DInstance from './Object3DInstance.svelte'
 
-  export let position: LightInstanceProperties['position']
-  export let scale: LightInstanceProperties['scale']
-  export let rotation: LightInstanceProperties['rotation']
-  export let viewportAware: LightInstanceProperties['viewportAware']
-  export let inViewport: LightInstanceProperties['inViewport']
-  export let castShadow: LightInstanceProperties['castShadow']
-  export let receiveShadow: LightInstanceProperties['receiveShadow']
-  export let frustumCulled: LightInstanceProperties['frustumCulled']
-  export let renderOrder: LightInstanceProperties['renderOrder']
-  export let lookAt: LightInstanceProperties['lookAt']
-
   export let light: LightInstanceProperties['light']
-  export let color: LightInstanceProperties['color']
-  export let intensity: LightInstanceProperties['intensity']
+
+  export let position: LightInstanceProperties['position'] = undefined
+  export let scale: LightInstanceProperties['scale'] = undefined
+  export let rotation: LightInstanceProperties['rotation'] = undefined
+  export let lookAt: LightInstanceProperties['lookAt'] = undefined
+  export let viewportAware: LightInstanceProperties['viewportAware'] = false
+  export let inViewport: LightInstanceProperties['inViewport'] = false
+  export let castShadow: LightInstanceProperties['castShadow'] = undefined
+  export let receiveShadow: LightInstanceProperties['receiveShadow'] = undefined
+  export let frustumCulled: LightInstanceProperties['frustumCulled'] = undefined
+  export let renderOrder: LightInstanceProperties['renderOrder'] = undefined
+
+  export let color: LightInstanceProperties['color'] = undefined
+  export let intensity: LightInstanceProperties['intensity'] = undefined
 
   const { invalidate } = useThrelte()
   const { linear } = useThrelteRoot()

--- a/src/lib/instances/MeshInstance.svelte
+++ b/src/lib/instances/MeshInstance.svelte
@@ -4,18 +4,18 @@
   import Object3DInstance from './Object3DInstance.svelte'
 
   export let mesh: MeshInstanceProperties['mesh']
-  export let position: MeshInstanceProperties['position']
-  export let scale: MeshInstanceProperties['scale']
-  export let rotation: MeshInstanceProperties['rotation']
-  export let viewportAware: MeshInstanceProperties['viewportAware']
-  export let inViewport: MeshInstanceProperties['inViewport']
-  export let castShadow: MeshInstanceProperties['castShadow']
-  export let receiveShadow: MeshInstanceProperties['receiveShadow']
-  export let frustumCulled: MeshInstanceProperties['frustumCulled']
-  export let renderOrder: MeshInstanceProperties['renderOrder']
-  export let lookAt: MeshInstanceProperties['lookAt']
-  export let interactive: MeshInstanceProperties['interactive']
-  export let ignorePointer: MeshInstanceProperties['ignorePointer']
+  export let position: MeshInstanceProperties['position'] = undefined
+  export let scale: MeshInstanceProperties['scale'] = undefined
+  export let rotation: MeshInstanceProperties['rotation'] = undefined
+  export let lookAt: MeshInstanceProperties['lookAt'] = undefined
+  export let viewportAware: MeshInstanceProperties['viewportAware'] = false
+  export let inViewport: MeshInstanceProperties['inViewport'] = false
+  export let castShadow: MeshInstanceProperties['castShadow'] = undefined
+  export let receiveShadow: MeshInstanceProperties['receiveShadow'] = undefined
+  export let frustumCulled: MeshInstanceProperties['frustumCulled'] = undefined
+  export let renderOrder: MeshInstanceProperties['renderOrder'] = undefined
+  export let interactive: MeshInstanceProperties['interactive'] = false
+  export let ignorePointer: MeshInstanceProperties['ignorePointer'] = false
 </script>
 
 <Object3DInstance

--- a/src/lib/instances/Object3DInstance.svelte
+++ b/src/lib/instances/Object3DInstance.svelte
@@ -8,21 +8,18 @@
 
   export let object: Object3DInstanceProperties['object']
 
-  // TransformableObject
-  export let position: Object3DInstanceProperties['position']
-  export let scale: Object3DInstanceProperties['scale']
-  export let rotation: Object3DInstanceProperties['rotation']
-  export let lookAt: Object3DInstanceProperties['lookAt']
+  export let position: Object3DInstanceProperties['position'] = undefined
+  export let scale: Object3DInstanceProperties['scale'] = undefined
+  export let rotation: Object3DInstanceProperties['rotation'] = undefined
+  export let lookAt: Object3DInstanceProperties['lookAt'] = undefined
 
-  // ViewportAwareObject
-  export let viewportAware: Object3DInstanceProperties['viewportAware']
-  export let inViewport: Object3DInstanceProperties['inViewport']
+  export let viewportAware: Object3DInstanceProperties['viewportAware'] = false
+  export let inViewport: Object3DInstanceProperties['inViewport'] = false
 
-  // self
-  export let castShadow: Object3DInstanceProperties['castShadow']
-  export let receiveShadow: Object3DInstanceProperties['receiveShadow']
-  export let frustumCulled: Object3DInstanceProperties['frustumCulled']
-  export let renderOrder: Object3DInstanceProperties['renderOrder']
+  export let castShadow: Object3DInstanceProperties['castShadow'] = undefined
+  export let receiveShadow: Object3DInstanceProperties['receiveShadow'] = undefined
+  export let frustumCulled: Object3DInstanceProperties['frustumCulled'] = undefined
+  export let renderOrder: Object3DInstanceProperties['renderOrder'] = undefined
 
   const { invalidate } = useThrelte()
   const getObject = () => object

--- a/src/lib/internal/InteractiveObject.svelte
+++ b/src/lib/internal/InteractiveObject.svelte
@@ -9,8 +9,8 @@
   export let object: InteractiveObjectProperties['object']
   let previousObject: InteractiveObjectProperties['object'] | undefined
 
-  export let interactive: InteractiveObjectProperties['interactive']
-  export let ignorePointer: InteractiveObjectProperties['ignorePointer']
+  export let interactive: InteractiveObjectProperties['interactive'] = false
+  export let ignorePointer: InteractiveObjectProperties['ignorePointer'] = false
 
   const eventDispatcher = createEventDispatcher<{
     click: ThreltePointerEvent

--- a/src/lib/internal/TransformableObject.svelte
+++ b/src/lib/internal/TransformableObject.svelte
@@ -5,10 +5,10 @@
   import type { TransformableObjectProperties } from '../types/components'
 
   export let object: TransformableObjectProperties['object']
-  export let position: TransformableObjectProperties['position']
-  export let scale: TransformableObjectProperties['scale']
-  export let rotation: TransformableObjectProperties['rotation']
-  export let lookAt: TransformableObjectProperties['lookAt']
+  export let position: TransformableObjectProperties['position'] = undefined
+  export let scale: TransformableObjectProperties['scale'] = undefined
+  export let rotation: TransformableObjectProperties['rotation'] = undefined
+  export let lookAt: TransformableObjectProperties['lookAt'] = undefined
 
   const targetWorldPos = new Vector3()
 

--- a/src/lib/internal/ViewportAwareObject.svelte
+++ b/src/lib/internal/ViewportAwareObject.svelte
@@ -7,7 +7,7 @@
   import type { ViewportAwareObjectProperties } from '../types/components'
 
   export let object: ViewportAwareObjectProperties['object']
-  export let viewportAware: ViewportAwareObjectProperties['viewportAware']
+  export let viewportAware: ViewportAwareObjectProperties['viewportAware'] = false
 
   const dispatch = createEventDispatcher<{
     viewportenter: Object3D

--- a/src/lib/lights/DirectionalLight.svelte
+++ b/src/lib/lights/DirectionalLight.svelte
@@ -71,19 +71,11 @@
 
 {#if target && !(target instanceof Object3D)}
   <HierarchicalObject object={originalTarget} />
-
-  <TransformableObject
-    object={originalTarget}
-    position={target}
-    scale={undefined}
-    rotation={undefined}
-    lookAt={undefined}
-  />
+  <TransformableObject object={originalTarget} position={target} />
 {/if}
 
 <LightInstance
   {light}
-  lookAt={undefined}
   {position}
   {scale}
   {rotation}


### PR DESCRIPTION
As I more and more use the instance components I find myself doing this a lot:

```svelte
<Object3DInstance
  {object}
  {position}
  scale={undefined}
  rotation={undefined}
  lookAt={undefined}
  castShadow={undefined}
  receiveShadow={undefined}
  frustumCulled={undefined}
  renderOrder={undefined}
  viewportAware={false}
  inViewport={false}
/>
```

instead of this

```svelte
<Object3DInstance {object} {position} />
```

to make the IDE happy. It's a lot of boilerplate. It's been used to not forget anything when setting up an object from scratch but I think there are better ways (to come…).