### PR TITLE
Fixed wrong event type bug in OrbitControl events

### DIFF
--- a/src/lib/controls/OrbitControls.svelte
+++ b/src/lib/controls/OrbitControls.svelte
@@ -55,7 +55,7 @@
     dispatch('change')
   }
   const onStart = () => dispatch('start')
-  const onEnd = () => dispatch('start')
+  const onEnd = () => dispatch('end')
 
   export const controls = new ThreeOrbitControls($parent, renderer.domElement)
   getThrelteUserData($parent).orbitControls = controls


### PR DESCRIPTION
The OrbitControl end-event is currently not working, see proposed change.